### PR TITLE
An example image component for pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   reactStrictMode: true,
-}
+  images: {
+    domains: ["images.ctfassets.net"],
+  },
+};

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -1,10 +1,23 @@
 import { Layout } from "../components/Layout/Layout";
 import { getPages, getPageBySlug, getPageNavigation } from "../lib/api";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import Image from "next/image";
 
 export default function Page({ page, navigation }) {
   return (
     <Layout {...navigation}>
+      {page && page?.fields?.heroImage && (
+        <Image
+          alt={page?.fields?.heroImage?.fields?.title}
+          src={`https:${page?.fields?.heroImage?.fields?.file?.url}?fm=webp`} // Force webp as the default image format here
+          layout="responsive"
+          width={700}
+          height={475}
+          placeholder="blur"
+          blurDataURL={`https:${page?.fields?.heroImage?.fields?.file?.url}?fm=jpg&q=1`} // Use a super low quality jpg as the blur data url
+          priority
+        />
+      )}
       {page && <h1>{page?.fields?.title}</h1>}
       {page && documentToReactComponents(page?.fields?.mainContent)}
     </Layout>


### PR DESCRIPTION
This PR adds an example image component for the main pages. It forces the image format to webp and provides a low quality jpg as the blurred image while it's loading.